### PR TITLE
Add base rental management model and Immeuble CRUD

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 

--- a/src/main/java/org/example/examen/controller/ImmeubleController.java
+++ b/src/main/java/org/example/examen/controller/ImmeubleController.java
@@ -1,0 +1,53 @@
+package org.example.examen.controller;
+
+import org.example.examen.model.Immeuble;
+import org.example.examen.service.ImmeubleService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/immeubles")
+public class ImmeubleController {
+
+    private final ImmeubleService service;
+
+    public ImmeubleController(ImmeubleService service) {
+        this.service = service;
+    }
+
+    @GetMapping
+    public List<Immeuble> getAll() {
+        return service.findAll();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Immeuble> getById(@PathVariable Long id) {
+        return service.findById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    public Immeuble create(@RequestBody Immeuble immeuble) {
+        return service.save(immeuble);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Immeuble> update(@PathVariable Long id, @RequestBody Immeuble immeuble) {
+        return service.findById(id)
+                .map(existing -> {
+                    immeuble.setId(id);
+                    return ResponseEntity.ok(service.save(immeuble));
+                })
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        service.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+}
+

--- a/src/main/java/org/example/examen/model/Contrat.java
+++ b/src/main/java/org/example/examen/model/Contrat.java
@@ -1,0 +1,38 @@
+package org.example.examen.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class Contrat {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private LocalDate dateDebut;
+
+    private LocalDate dateFin;
+
+    private double montant;
+
+    @ManyToOne
+    @JoinColumn(name = "unite_id")
+    private UniteLocation uniteLocation;
+
+    @ManyToOne
+    @JoinColumn(name = "locataire_id")
+    private Locataire locataire;
+
+    @OneToMany(mappedBy = "contrat", cascade = CascadeType.ALL)
+    private List<Paiement> paiements = new ArrayList<>();
+}
+

--- a/src/main/java/org/example/examen/model/Immeuble.java
+++ b/src/main/java/org/example/examen/model/Immeuble.java
@@ -1,0 +1,31 @@
+package org.example.examen.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class Immeuble {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String nom;
+
+    private String adresse;
+
+    private String description;
+
+    private int nombreUnites;
+
+    @OneToMany(mappedBy = "immeuble", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<UniteLocation> unites = new ArrayList<>();
+}
+

--- a/src/main/java/org/example/examen/model/Locataire.java
+++ b/src/main/java/org/example/examen/model/Locataire.java
@@ -1,0 +1,29 @@
+package org.example.examen.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class Locataire {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String nom;
+
+    private String email;
+
+    private String motDePasse;
+
+    @OneToMany(mappedBy = "locataire", cascade = CascadeType.ALL)
+    private List<Contrat> contrats = new ArrayList<>();
+}
+

--- a/src/main/java/org/example/examen/model/Paiement.java
+++ b/src/main/java/org/example/examen/model/Paiement.java
@@ -1,0 +1,29 @@
+package org.example.examen.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class Paiement {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private LocalDate datePaiement;
+
+    private double montant;
+
+    private String statut; // paye ou en_retard
+
+    @ManyToOne
+    @JoinColumn(name = "contrat_id")
+    private Contrat contrat;
+}
+

--- a/src/main/java/org/example/examen/model/UniteLocation.java
+++ b/src/main/java/org/example/examen/model/UniteLocation.java
@@ -1,0 +1,31 @@
+package org.example.examen.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class UniteLocation {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String numero;
+
+    private double surface;
+
+    private int pieces;
+
+    private double loyer;
+
+    private String statut; // disponible ou occupe
+
+    @ManyToOne
+    @JoinColumn(name = "immeuble_id")
+    private Immeuble immeuble;
+}
+

--- a/src/main/java/org/example/examen/model/Utilisateur.java
+++ b/src/main/java/org/example/examen/model/Utilisateur.java
@@ -1,0 +1,23 @@
+package org.example.examen.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class Utilisateur {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String username;
+
+    private String password;
+
+    private String role; // ADMIN, PROPRIETAIRE, LOCATAIRE
+}
+

--- a/src/main/java/org/example/examen/repository/ContratRepository.java
+++ b/src/main/java/org/example/examen/repository/ContratRepository.java
@@ -1,0 +1,8 @@
+package org.example.examen.repository;
+
+import org.example.examen.model.Contrat;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ContratRepository extends JpaRepository<Contrat, Long> {
+}
+

--- a/src/main/java/org/example/examen/repository/ImmeubleRepository.java
+++ b/src/main/java/org/example/examen/repository/ImmeubleRepository.java
@@ -1,0 +1,8 @@
+package org.example.examen.repository;
+
+import org.example.examen.model.Immeuble;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ImmeubleRepository extends JpaRepository<Immeuble, Long> {
+}
+

--- a/src/main/java/org/example/examen/repository/LocataireRepository.java
+++ b/src/main/java/org/example/examen/repository/LocataireRepository.java
@@ -1,0 +1,8 @@
+package org.example.examen.repository;
+
+import org.example.examen.model.Locataire;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LocataireRepository extends JpaRepository<Locataire, Long> {
+}
+

--- a/src/main/java/org/example/examen/repository/PaiementRepository.java
+++ b/src/main/java/org/example/examen/repository/PaiementRepository.java
@@ -1,0 +1,8 @@
+package org.example.examen.repository;
+
+import org.example.examen.model.Paiement;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaiementRepository extends JpaRepository<Paiement, Long> {
+}
+

--- a/src/main/java/org/example/examen/repository/UniteLocationRepository.java
+++ b/src/main/java/org/example/examen/repository/UniteLocationRepository.java
@@ -1,0 +1,8 @@
+package org.example.examen.repository;
+
+import org.example.examen.model.UniteLocation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UniteLocationRepository extends JpaRepository<UniteLocation, Long> {
+}
+

--- a/src/main/java/org/example/examen/repository/UtilisateurRepository.java
+++ b/src/main/java/org/example/examen/repository/UtilisateurRepository.java
@@ -1,0 +1,9 @@
+package org.example.examen.repository;
+
+import org.example.examen.model.Utilisateur;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UtilisateurRepository extends JpaRepository<Utilisateur, Long> {
+    Utilisateur findByUsername(String username);
+}
+

--- a/src/main/java/org/example/examen/service/ImmeubleService.java
+++ b/src/main/java/org/example/examen/service/ImmeubleService.java
@@ -1,0 +1,35 @@
+package org.example.examen.service;
+
+import org.example.examen.model.Immeuble;
+import org.example.examen.repository.ImmeubleRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class ImmeubleService {
+
+    private final ImmeubleRepository repository;
+
+    public ImmeubleService(ImmeubleRepository repository) {
+        this.repository = repository;
+    }
+
+    public List<Immeuble> findAll() {
+        return repository.findAll();
+    }
+
+    public Optional<Immeuble> findById(Long id) {
+        return repository.findById(id);
+    }
+
+    public Immeuble save(Immeuble immeuble) {
+        return repository.save(immeuble);
+    }
+
+    public void delete(Long id) {
+        repository.deleteById(id);
+    }
+}
+


### PR DESCRIPTION
## Summary
- Define JPA entities for core rental concepts
- Add repositories and service layer for Immeuble
- Implement REST controller exposing Immeuble CRUD endpoints
- Configure project to build with Java 21

## Testing
- `./gradlew test` *(fails: Could not resolve dependencies from Maven Central; received 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68934ff1070c832395e210df10e48d6a