### PR TITLE
Ajoutez la configuration Spring Security avec un contrôle d'accès basé sur les rôles 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,10 +25,11 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    // Sécurité
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.postgresql:postgresql'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/org/example/examen/config/SecurityConfig.java
+++ b/src/main/java/org/example/examen/config/SecurityConfig.java
@@ -1,0 +1,52 @@
+package org.example.examen.config;
+
+import org.example.examen.service.CustomUserDetailsService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.password.NoOpPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+    private final CustomUserDetailsService userDetailsService;
+
+    public SecurityConfig(CustomUserDetailsService userDetailsService) {
+        this.userDetailsService = userDetailsService;
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return NoOpPasswordEncoder.getInstance();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(HttpSecurity http) throws Exception {
+        AuthenticationManagerBuilder builder = http.getSharedObject(AuthenticationManagerBuilder.class);
+        builder.userDetailsService(userDetailsService).passwordEncoder(passwordEncoder());
+        return builder.build();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.csrf(csrf -> csrf.disable());
+        http.authorizeHttpRequests(auth -> auth
+                .requestMatchers("/login", "/locataires/inscription", "/locataires/connexion").permitAll()
+                .requestMatchers("/admin/**").hasRole("ADMIN")
+                .requestMatchers("/contrats/**", "/paiements/**", "/api/**").hasAnyRole("ADMIN", "PROPRIETAIRE")
+                .requestMatchers("/locataires/**").hasRole("LOCATAIRE")
+                .anyRequest().authenticated()
+        );
+        http.formLogin(form -> form
+                .loginPage("/login").permitAll()
+        );
+        http.logout(logout -> logout.permitAll());
+        return http.build();
+    }
+}
+

--- a/src/main/java/org/example/examen/controller/AuthController.java
+++ b/src/main/java/org/example/examen/controller/AuthController.java
@@ -1,0 +1,13 @@
+package org.example.examen.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class AuthController {
+    @GetMapping("/login")
+    public String login() {
+        return "login";
+    }
+}
+

--- a/src/main/java/org/example/examen/service/CustomUserDetailsService.java
+++ b/src/main/java/org/example/examen/service/CustomUserDetailsService.java
@@ -1,0 +1,32 @@
+package org.example.examen.service;
+
+import org.example.examen.model.Utilisateur;
+import org.example.examen.repository.UtilisateurRepository;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+    private final UtilisateurRepository repository;
+
+    public CustomUserDetailsService(UtilisateurRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Utilisateur utilisateur = repository.findByUsername(username);
+        if (utilisateur == null) {
+            throw new UsernameNotFoundException("Utilisateur non trouvé");
+        }
+        return User.builder()
+                .username(utilisateur.getUsername())
+                .password(utilisateur.getPassword())
+                .roles(utilisateur.getRole())
+                .build();
+    }
+}
+

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8" />
+    <title>Connexion</title>
+</head>
+<body>
+<h1>Connexion</h1>
+<div th:if="${param.error}">Nom d'utilisateur ou mot de passe invalide</div>
+<form th:action="@{/login}" method="post">
+    <label>Nom d'utilisateur : <input type="text" name="username" /></label><br/>
+    <label>Mot de passe : <input type="password" name="password" /></label><br/>
+    <button type="submit">Se connecter</button>
+</form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- configure Spring Security with role-based access rules for admins, proprietors, and tenants
- implement `CustomUserDetailsService` and login controller
- add login view and declare necessary security dependencies

## Testing
- `./gradlew test` *(fails: Could not resolve org.springframework.boot:spring-boot-starter-test:3.5.4 (403 Forbidden))*

------
https://chatgpt.com/codex/tasks/task_e_68935d2fdd648323848c3b7df0245f4c