### PR TITLE
Configure database profiles and JPA dialect

### DIFF
--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,0 +1,5 @@
+spring.datasource.url=jdbc:postgresql://localhost:5432/examen
+spring.datasource.username=postgres
+spring.datasource.password=postgres
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.hibernate.ddl-auto=update

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,0 +1,5 @@
+spring.datasource.url=jdbc:postgresql://prod-host:5432/examen
+spring.datasource.username=prod_user
+spring.datasource.password=prod_pass
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.hibernate.ddl-auto=validate

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -1,0 +1,6 @@
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.username=sa
+spring.datasource.password=
+spring.datasource.driverClassName=org.h2.Driver
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=create-drop

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 spring.application.name=examen
 spring.flyway.enabled=true
 spring.flyway.locations=classpath:db/migration
+spring.profiles.active=dev

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+spring.profiles.active=test


### PR DESCRIPTION
## Summary
- add dev, test and prod datasource settings with JPA dialect and schema generation
- set default profile to dev and enable test profile during tests

## Testing
- `./gradlew test` *(fails: Could not resolve dependencies; received status code 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_6893650d9944832384ac8478efbed5b8